### PR TITLE
added a button to enable clear local storage

### DIFF
--- a/app/javascript/plugins/show_list.js
+++ b/app/javascript/plugins/show_list.js
@@ -5,17 +5,25 @@ const showList = () => {
     const restsArr = JSON.parse(window.localStorage.list)
     // restList.innerHTML = localStorage.getItem("list")
     restsArr.forEach((obj) => {
-      // console.log(obj.restName);
       restList.insertAdjacentHTML("beforeend", `<li>${obj.restName}</li>`)
-      // restList.innerHTML = obj.restName;
     })
-    // console.log(restsArr);
+    deleteList();
   }
 }
 
 // export const getList = () => {
 //   return window.localStorage.list
 // }
+
+const deleteList = () => {
+  // when click on clear link
+  const deleteL = document.querySelector('.deleteL')
+  deleteL.addEventListener('click', (e) => {
+    window.localStorage.clear();
+  })
+}
+
+
 
 
 export { showList }

--- a/app/views/restaurants/index.html.erb
+++ b/app/views/restaurants/index.html.erb
@@ -41,7 +41,7 @@
               <h2 class="text-left rest-name"><u><%= restaurant.name.first(60) %></u></h2>
             <!-- begins contains image and desc -->
               <div class="d-flex">
-                <!-- Image -->
+          <!-- Image -->
                 <%= cl_image_tag(restaurant.photo.key, :transformation=>[
                   {height: 160, width: 240, crop: :fill},
                   {:radius=>12}]) %>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -8,27 +8,33 @@
     </div>
   </table>
   <!-- user logged in -->
+    <div class="btn btn-primary deleteL">
+      <%= link_to "Clear list" %>
+    </div>
+
   <% if current_user %>
-    <%= link_to "Create new list", new_user_list_path(current_user), data: {action: "click->list#createNewList"}, class:"btn btn-flat-reverse btn-block my-2"%>
+      <%= link_to "Create new list", new_user_list_path(current_user), data: {action: "click->list#createNewList"}, class:"btn btn-flat-reverse my-2"%>
   <% else %>
-    <button class="btn btn-flat-reverse btn-block dropdown-toggle " type="button" id="drop-down" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-      Register to continue!
-    </button>
-    <div class="dropdown-menu" aria-labelledby="drop-down">
-          <button
-                    type="button"
-                    class="dropdown-item"
-                    data-toggle="modal"
-                    data-target="#exampleModalB">
-                    Log in
-          </button>
-          <button
-                    type="button"
-                    class="dropdown-item"
-                    data-toggle="modal"
-                    data-target="#exampleModalA">
-                    Sign up
-          </button>
+    <div>
+      <button class="btn btn-flat-reverse dropdown-toggle " type="button" id="drop-down" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        Register to continue!
+      </button>
+      <div class="dropdown-menu" aria-labelledby="drop-down">
+            <button
+                      type="button"
+                      class="dropdown-item"
+                      data-toggle="modal"
+                      data-target="#exampleModalB">
+                      Log in
+            </button>
+            <button
+                      type="button"
+                      class="dropdown-item"
+                      data-toggle="modal"
+                      data-target="#exampleModalA">
+                      Sign up
+            </button>
+      </div>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
## Why

We need a clear local storage button as previously it was not possible without using the console log of browser.
This can be awkward when show casing to people.

## What

This pull request introduces the following:

At restaurant search page, the side bar now shows a blue button name "clear list".
clicking this button will enable to clearing of local storage, then the temporary list will be cleared.

## How to Test

Add a few restaurants to the list. Then click the clear list button.